### PR TITLE
Fix: Add 32-bit support to devcontainer setup

### DIFF
--- a/.devcontainer/install-mizar.sh
+++ b/.devcontainer/install-mizar.sh
@@ -3,8 +3,10 @@ set -e
 
 echo "Starting Mizar installation..."
 
-# 1. Update package lists and install dependencies
-apt-get update && apt-get install -y wget tar
+# 1. Add i386 architecture and install dependencies
+dpkg --add-architecture i386
+apt-get update
+apt-get install -y libc6:i386 libncurses5:i386 libstdc++6:i386 wget tar
 
 # 2. Download the official Mizar archive 
 # URL for Mizar Version 8.1.15 with MML 5.94.1493


### PR DESCRIPTION
The Mizar installation script was failing because it was trying to run a 32-bit installer on a 64-bit system without the necessary compatibility libraries.

This change adds the i386 architecture and installs the required 32-bit libraries (libc6:i386, libncurses5:i386, libstdc++6:i386) to the devcontainer setup script. This allows the Mizar installer to run successfully.